### PR TITLE
Bump to 1.6.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG MTW_VERSION=1.6.6
+ARG MTW_VERSION=1.6.7
 ARG PYTHON_VERSION=3.12
 
 # Stage 1:

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,4 +71,4 @@ EXPOSE 55930
 
 # Run worker & server apps
 # TODO: stop listening on all interfaces via 0.0.0.0
-CMD python mtw-server.py --host 0.0.0.0 & python mtw-worker.py 
+CMD python mtw-server.py --host 0.0.0.0 & python mtw-worker.py

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ apt-get update && apt-get install nano
 nano conf/mtw-dist.ini
 ```
 
-Update the values `TARGET_YEAR`, `PREV_YEAR_DEF`, `PREV_YEARS` according ro your configuration.
+Update the values `TARGET_YEAR`, `PREV_YEAR_DEF`, `PREV_YEARS` according to your configuration.
 
 Save and exit: `CTRL+S`, `CTRL+X`
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ You can for example use the [Jena Docker image](https://github.com/stain/jena-do
 
 ```bash
 docker run --rm \
---volume /$(pwd)/mesh-data/:/rdf \
-stain/jena riot --validate mesh.nt.gz mesh-trx_YYYY-MM-DD.nt.gz
+    --volume /$(pwd)/mesh-data/:/rdf \
+    stain/jena riot --validate mesh.nt.gz mesh-trx_YYYY-MM-DD.nt.gz
 ```
 
 A special service called `staging` is part of the Compose file to load the MeSH data into the triple store.  
@@ -175,17 +175,17 @@ If the `mesh_YYYY-MM-DD_....nt.gz` and  `mesh.nt.gz` files are stored in our loc
 
 ```bash
 docker run --rm \
---volume /$(pwd)/mesh-data/:/rdf stain/jena \
-riot --validate mesh.nt.gz mesh_YYYY-MM-DD_....nt.gz
+    --volume /$(pwd)/mesh-data/:/rdf stain/jena \
+    riot --validate mesh.nt.gz mesh_YYYY-MM-DD_....nt.gz
 ```
 
 ### Extract the translation from the backup using mesh-nt2trx tool
 
 ```bash
 docker run -it --rm \
---volume /$(pwd)/mesh-data/:/rdf \
---workdir //rdf mtw-server \
-python3 //app/tools/mesh-nt2trx.py mesh_YYYY-MM-DD_....nt.gz
+    --volume /$(pwd)/mesh-data/:/rdf \
+    --workdir //rdf mtw-server \
+    python3 //app/tools/mesh-nt2trx.py mesh_YYYY-MM-DD_....nt.gz
 ```
 
 You should now have a translation file `mtw-trx_YYYY-MM-DD.nt.gz` in your local `mesh-data` folder.
@@ -218,9 +218,9 @@ Follow the steps in [Loading the MeSH datasets](#loading-the-mesh-datasets)
 
 ```bash
 docker run -it --rm \
---volume mtw_mtw-data:/app/instance/ \
---workdir //app/instance/ \
-mtw-server bash
+    --volume mtw_mtw-data:/app/instance/ \
+    --workdir //app/instance/ \
+    mtw-server bash
 ```
 
 ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
     init: true  # Use tini to handle messages
     # TODO: move to entrypoint.sh
     # TODO: listen to container's ip rather than listening on all interface (0.0.0.0)
-    command: > 
+    command: >
             bash -c "python /app/set-mtw-admin.py --login $${ADMIN_LOGIN} --pwd $$(cat /run/secrets/admin-settings)
             && python mtw-server.py --host 0.0.0.0 $${DEBUG} & python mtw-worker.py $${DEBUG}"
     depends_on:

--- a/mtw-dist.ini
+++ b/mtw-dist.ini
@@ -11,12 +11,12 @@
 
 ### ! Fully qualified domain name - required !
 ##  - You can override it with --fqdn param when running mtw-server
-#SERVER_NAME = test.medvik.cz
+SERVER_NAME = test.medvik.cz
 
-### You MUST copy the content of the static dir 
-###  into Apache htdocs root or the equivalent 
+### You MUST copy the content of the static dir
+###  into Apache htdocs root or the equivalent
 ###  and rename it to: assets-mtw
-##  Add to Apache config: 
+##  Add to Apache config:
 ##   RewriteEngine on
 ##   RewriteRule ^/<prefix>/assets-mtw/(.*) /assets-mtw/$1
 
@@ -97,7 +97,7 @@ GCSP = {"script-src":  "'self' ",
         "img-src":     "'self' *.medvik.cz *.nlk.cz data:"
         }
 
-CHAR_NORM_FILE = norm_chars_table.tsv.txt         
+CHAR_NORM_FILE = norm_chars_table.tsv.txt
 
 
 [worker]


### PR DESCRIPTION
- Update to MTW 1.6.7
- Update to latest `mtw-dist.ini` file
- Various formatting, whitespace and typo fixes